### PR TITLE
Added port and change host ip

### DIFF
--- a/Assignments/Extras.md
+++ b/Assignments/Extras.md
@@ -33,11 +33,11 @@ Once the container is up and running, prove that your settings are correctly app
 
 Connect to your database as the root user and check for the existence of the beer database:
 
-`echo "show databases;" | mysql -uduffman -h 192.168.88.4 -psaysoyeah`
+`echo "show databases;" | mysql -uduffman -h 0.0.0.0 -psaysoyeah -P 3307`
 
 Run the command located in /sql/beer.sql to insert values into the database.
 
-`mysql -uroot -h 192.168.88.4 -pSQLp4ss < /sql/beer.sql`
+`mysql -uroot -h 0.0.0.0 -pSQLp4ss -P 3307 < /sql/beer.sql`
 
 
 ## Task 9


### PR DESCRIPTION
Since the task calls for forwarding host port `3307` to container port `3306`, the mysql client instructions need to be updated so that the learner can connect without having to look up the mysql client parameter to connect. In addition, since the instruction calls for exposing the port without restricting the IP, the host IP to changed to `0.0.0.0` to avoid confusing the learner with an IP that may not exist on their machine.